### PR TITLE
Allow bosh lite LATs to run without the TrafficController

### DIFF
--- a/jobs/lats/spec
+++ b/jobs/lats/spec
@@ -13,6 +13,7 @@ templates:
 consumes:
 - name: trafficcontroller
   type: trafficcontroller
+  optional: true
 - name: reverse_log_proxy
   type: reverse_log_proxy
 

--- a/jobs/lats/templates/config.json.erb
+++ b/jobs/lats/templates/config.json.erb
@@ -1,15 +1,17 @@
 <%
   require 'json'
 
-  tc = link("trafficcontroller")
-
   config = {
     "IP" => spec.ip,
-    "DopplerEndpoint" => "ws://" + tc.instances.first.address + ":" + tc.p("loggregator.outgoing_dropsonde_port").to_s,
     "ReverseLogProxyAddr" => "#{link('reverse_log_proxy').address}:8082",
     "SkipSSLVerify" => properties.ssl.skip_cert_verify,
     "DropsondePort" => properties.metron_agent.dropsonde_incoming_port
   }
+
+  if_link("trafficcontroller") do |tc|
+    config["DopplerEndpoint"] = "ws://" + tc.instances.first.address + ":" + tc.p("loggregator.outgoing_dropsonde_port").to_s
+  end
+
 %>
 
 <%= JSON.pretty_generate(config) %>

--- a/manifests/operations/no-traffic-controller.yml
+++ b/manifests/operations/no-traffic-controller.yml
@@ -1,0 +1,3 @@
+---
+- type: remove
+  path: /instance_groups/name=lats/jobs/name=lats/consumes/trafficcontroller?

--- a/scripts/deploy-bosh-lite
+++ b/scripts/deploy-bosh-lite
@@ -1,15 +1,15 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-set -e -x
+set -ex
 
-env_name=$1
-if [ "$env_name" == '' ]
-then
-    env_name=lite
-fi
+env_name="${1:-lite}"
 
 bosh create-release --force
-bosh -e $env_name upload-release --rebase
-bosh -e $env_name deploy -n -d lats manifests/lats.yml \
+bosh upload-release --environment="$env_name" --rebase
+bosh deploy manifests/lats.yml \
+    --ops-file=manifests/operations/no-traffic-controller.yml \
     --vars-store=/tmp/lats-vars.yml \
-    --vars-file=/tmp/loggregator-vars.yml
+    --vars-file=/tmp/loggregator-vars.yml \
+    --environment="$env_name" \
+    --deployment=lats \
+    --non-interactive

--- a/scripts/lats
+++ b/scripts/lats
@@ -1,3 +1,10 @@
 #!/bin/bash
 
-bosh -e lite -d lats run-errand lats
+set -ex
+
+env_name="${1:-lite}"
+
+bosh run-errand lats \
+    --keep-alive \
+    --environment="$env_name" \
+    --deployment=lats


### PR DESCRIPTION
- Allow link to be optional
- Provide ops file to remove TC link from manifest
- Have deploy-bosh-lite script use ops file to disable TC
- Make scripts more consistent
- Use LATs version that can skip TC tests

Related: https://github.com/cloudfoundry/logging-acceptance-tests/pull/2